### PR TITLE
[cli] Make error for no ports in config write to stderr so json output is unaffected

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -132,7 +132,7 @@ class InterfaceAliasConverter(object):
 
         if not self.port_dict:
             if not device_info.is_supervisor():
-                click.echo(message="Configuration database contains no ports")
+                click.echo(message="Configuration database contains no ports", err=True)
             self.port_dict = {}
 
         for port_name in self.port_dict:


### PR DESCRIPTION
#### What I did

I changed the warning which is given in `InterfaceAliasConverter` to output over `stderr` because it was breaking the `--json` output of multiple `show` commands and as a result was causing `warm-reboot` to fail. 

#### How I did it

Changed output of warning from stdout to stderr

#### How to verify it

Do a warm-reboot without any ports configured on the system. You can also do `show platform summary --json | tee output` with a zero port configuration as well and confirm that `output` does not contain the zero port warning. 

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A
